### PR TITLE
Updating dll path and fixed warnings

### DIFF
--- a/XamForms.Controls.Calendar.Droid/XamForms.Controls.Calendar.Droid.csproj
+++ b/XamForms.Controls.Calendar.Droid/XamForms.Controls.Calendar.Droid.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Xamarin.Forms.3.0.0.561731\build\netstandard2.0\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.3.0.0.561731\build\netstandard2.0\Xamarin.Forms.props')" />
   <Import Project="..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.4\build\Xamarin.Build.Download.props')" />
@@ -16,7 +16,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/XamForms.Controls.Calendar.iOS/CalendarButtonRenderer.cs
+++ b/XamForms.Controls.Calendar.iOS/CalendarButtonRenderer.cs
@@ -134,8 +134,10 @@ namespace XamForms.Controls.iOS
 	{
 		public static void Init()
 		{
-			var d = "";
-		}
+#pragma warning disable CS0219 // Variable is assigned but its value is never used
+            var d = "";
+#pragma warning restore CS0219 // Variable is assigned but its value is never used
+        }
 	}
 }
 

--- a/XamForms.Controls.Calendar.nuspec
+++ b/XamForms.Controls.Calendar.nuspec
@@ -23,6 +23,10 @@
          <dependency id="Xamarin.Forms" version="3.0.0.561731" />
        </dependencies>
        <releaseNotes>
+     [1.2.1]
+     - Updated to resolve reference to core dll
+     - Added suppression for CS0219 in iOS Init method
+     - Changed BorderRadius to CornerRadius
 	 [1.2.0]
 	 - Updated to .NET Standard 2.0 (UWP requires Build 1709 - Fall Creators Update)
 	 - Updated to Xamarin Forms 3.0.0.561731 
@@ -78,7 +82,7 @@
    </metadata>
    <files>
       <!--Core-->
-     <file src="XamForms.Controls.Calendar/bin/Release/XamForms.Controls.Calendar.dll" target="lib/portable-net45+wp8+win8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10/XamForms.Controls.Calendar.dll" />
+     <file src="XamForms.Controls.Calendar/bin/Release/netstandard2.0/XamForms.Controls.Calendar.dll" target="lib/portable-net45+wp8+win8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10/XamForms.Controls.Calendar.dll" />
       
      <!--UWP-->
      <file src="XamForms.Controls.Calendar.UWP/bin/Release/XamForms.Controls.Calendar.UWP.dll" target="lib/UAP10/XamForms.Controls.Calendar.UWP.dll" />

--- a/XamForms.Controls.Calendar/Calendar.MonthNavigation.cs
+++ b/XamForms.Controls.Calendar/Calendar.MonthNavigation.cs
@@ -205,12 +205,12 @@ namespace XamForms.Controls
 		}
 
 		public static readonly BindableProperty TitleLeftArrowBorderRadiusProperty = BindableProperty.Create(nameof(TitleLeftArrowBorderRadius), typeof(Int32), typeof(Calendar), default(Int32),
-					propertyChanged: (bindable, oldValue, newValue) => (bindable as Calendar).TitleLeftArrow.BorderRadius = (Int32)newValue);
+					propertyChanged: (bindable, oldValue, newValue) => (bindable as Calendar).TitleLeftArrow.CornerRadius = (Int32)newValue);
 
 		public Int32 TitleLeftArrowBorderRadius
 		{
-			get { return TitleLeftArrow.BorderRadius; }
-			set { TitleLeftArrow.BorderRadius = value; }
+			get { return TitleLeftArrow.CornerRadius; }
+			set { TitleLeftArrow.CornerRadius = value; }
 		}
 
 		public static readonly BindableProperty TitleLeftArrowImageProperty = BindableProperty.Create(nameof(TitleLeftArrowImage), typeof(FileImageSource), typeof(Calendar), default(FileImageSource),
@@ -331,12 +331,12 @@ namespace XamForms.Controls
 		}
 
 		public static readonly BindableProperty TitleRightArrowBorderRadiusProperty = BindableProperty.Create(nameof(TitleRightArrowBorderRadius), typeof(Int32), typeof(Calendar), default(Int32),
-					propertyChanged: (bindable, oldValue, newValue) => (bindable as Calendar).TitleRightArrow.BorderRadius = (Int32)newValue);
+					propertyChanged: (bindable, oldValue, newValue) => (bindable as Calendar).TitleRightArrow.CornerRadius = (Int32)newValue);
 
 		public Int32 TitleRightArrowBorderRadius
 		{
-			get { return TitleRightArrow.BorderRadius; }
-			set { TitleRightArrow.BorderRadius = value; }
+			get { return TitleRightArrow.CornerRadius; }
+			set { TitleRightArrow.CornerRadius = value; }
 		}
 
 		public static readonly BindableProperty TitleRightArrowImageProperty = BindableProperty.Create(nameof(TitleRightArrowImage), typeof(FileImageSource), typeof(Calendar), default(FileImageSource),


### PR DESCRIPTION
- Corrected path to core dll as it seems to contain ".netstandard2.0" in some automated builds. 
- Suppressed expected compiler warning in init method.
- Updated to use CornerRadius instead of BorderRadius as per Xamarin Forms 2.5+